### PR TITLE
app deps need to be saved in app/

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "fs-jetpack": "0.9.0",
     "imagemin": "5.2.2",
+    "imagemin-mozjpeg": "6.0.0",
     "imagemin-pngquant": "5.0.0"
   }
 }


### PR DESCRIPTION
The version of the boilerplate this repo is based on, uses 2 package json files. The one in app/ is the one that should be updated with app dependencies. This makes all app dependencies available when a release is built.